### PR TITLE
Self signed certificates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "transfers",
         "management"
     ],
-    "readme": "readme.md",
+    "readme": "README.md",
     "support": {
         "email": "thegrumpydictator@gmail.com",
         "issues": "https://github.com/firefly-iii/firefly-iii/issues",

--- a/src/Request/GetAccountRequest.php
+++ b/src/Request/GetAccountRequest.php
@@ -45,9 +45,11 @@ class GetAccountRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('accounts');

--- a/src/Request/GetAccountRequest.php
+++ b/src/Request/GetAccountRequest.php
@@ -49,7 +49,7 @@ class GetAccountRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('accounts');

--- a/src/Request/GetAccountRequest.php
+++ b/src/Request/GetAccountRequest.php
@@ -56,7 +56,7 @@ class GetAccountRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {

--- a/src/Request/GetAccountsRequest.php
+++ b/src/Request/GetAccountsRequest.php
@@ -57,7 +57,7 @@ class GetAccountsRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->type = 'all';
         $this->setBase($url);
         $this->setToken($token);

--- a/src/Request/GetAccountsRequest.php
+++ b/src/Request/GetAccountsRequest.php
@@ -53,9 +53,11 @@ class GetAccountsRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->type = 'all';
         $this->setBase($url);
         $this->setToken($token);

--- a/src/Request/GetAccountsRequest.php
+++ b/src/Request/GetAccountsRequest.php
@@ -65,13 +65,12 @@ class GetAccountsRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
-
 
     /**
      * @throws ApiHttpException

--- a/src/Request/GetBillsRequest.php
+++ b/src/Request/GetBillsRequest.php
@@ -44,7 +44,7 @@ class GetBillsRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('bills');

--- a/src/Request/GetBillsRequest.php
+++ b/src/Request/GetBillsRequest.php
@@ -40,9 +40,11 @@ class GetBillsRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('bills');

--- a/src/Request/GetBillsRequest.php
+++ b/src/Request/GetBillsRequest.php
@@ -49,13 +49,15 @@ class GetBillsRequest extends Request
         $this->setToken($token);
         $this->setUri('bills');
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
+
     /**
      * @throws ApiHttpException
      * @return Response

--- a/src/Request/GetBudgetsRequest.php
+++ b/src/Request/GetBudgetsRequest.php
@@ -37,9 +37,13 @@ class GetBudgetsRequest extends Request
 {
     /**
      * GetBudgetsRequest constructor.
+     * @param string $url
+     * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('budgets');

--- a/src/Request/GetBudgetsRequest.php
+++ b/src/Request/GetBudgetsRequest.php
@@ -85,8 +85,9 @@ class GetBudgetsRequest extends Request
 
         return new GetBudgetsResponse(array_merge(...$collectedRows));
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {

--- a/src/Request/GetBudgetsRequest.php
+++ b/src/Request/GetBudgetsRequest.php
@@ -43,7 +43,7 @@ class GetBudgetsRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('budgets');

--- a/src/Request/GetCategoriesRequest.php
+++ b/src/Request/GetCategoriesRequest.php
@@ -86,13 +86,15 @@ class GetCategoriesRequest extends Request
 
         return new GetCategoriesResponse(array_merge(...$collectedRows));
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
+
     /**
      * @return Response
      */

--- a/src/Request/GetCategoriesRequest.php
+++ b/src/Request/GetCategoriesRequest.php
@@ -40,9 +40,11 @@ class GetCategoriesRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('categories');

--- a/src/Request/GetCategoriesRequest.php
+++ b/src/Request/GetCategoriesRequest.php
@@ -44,7 +44,7 @@ class GetCategoriesRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('categories');

--- a/src/Request/GetCurrenciesRequest.php
+++ b/src/Request/GetCurrenciesRequest.php
@@ -40,9 +40,11 @@ class GetCurrenciesRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('currencies');

--- a/src/Request/GetCurrenciesRequest.php
+++ b/src/Request/GetCurrenciesRequest.php
@@ -86,13 +86,15 @@ class GetCurrenciesRequest extends Request
 
         return new GetCurrenciesResponse(array_merge(...$collectedRows));
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
+
     /**
      * @return Response
      */

--- a/src/Request/GetCurrenciesRequest.php
+++ b/src/Request/GetCurrenciesRequest.php
@@ -44,7 +44,7 @@ class GetCurrenciesRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('currencies');

--- a/src/Request/GetCurrencyRequest.php
+++ b/src/Request/GetCurrencyRequest.php
@@ -45,9 +45,11 @@ class GetCurrencyRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('currencies');

--- a/src/Request/GetCurrencyRequest.php
+++ b/src/Request/GetCurrencyRequest.php
@@ -49,7 +49,7 @@ class GetCurrencyRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('currencies');

--- a/src/Request/GetCurrencyRequest.php
+++ b/src/Request/GetCurrencyRequest.php
@@ -77,13 +77,15 @@ class GetCurrencyRequest extends Request
     {
         // TODO: Implement post() method.
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
+
     /**
      * @param string $code
      */

--- a/src/Request/GetPreferenceRequest.php
+++ b/src/Request/GetPreferenceRequest.php
@@ -86,13 +86,15 @@ class GetPreferenceRequest extends Request
         $this->name = $name;
         $this->setUri(sprintf('preferences/%s', $name));
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
+
     /**
      * @return Response
      */

--- a/src/Request/GetPreferenceRequest.php
+++ b/src/Request/GetPreferenceRequest.php
@@ -49,7 +49,7 @@ class GetPreferenceRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('preferences');

--- a/src/Request/GetPreferenceRequest.php
+++ b/src/Request/GetPreferenceRequest.php
@@ -45,9 +45,11 @@ class GetPreferenceRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('preferences');

--- a/src/Request/GetSearchAccountRequest.php
+++ b/src/Request/GetSearchAccountRequest.php
@@ -49,7 +49,7 @@ class GetSearchAccountRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('search/accounts');

--- a/src/Request/GetSearchAccountRequest.php
+++ b/src/Request/GetSearchAccountRequest.php
@@ -45,9 +45,11 @@ class GetSearchAccountRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('search/accounts');

--- a/src/Request/GetSearchAccountRequest.php
+++ b/src/Request/GetSearchAccountRequest.php
@@ -123,13 +123,15 @@ class GetSearchAccountRequest extends Request
         $this->query = $query;
         $this->setParameters(['query' => $query, 'field' => $this->getField()]);
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
         // TODO: Implement put() method.
     }
+
     /**
      * @return Response
      */

--- a/src/Request/PostTagRequest.php
+++ b/src/Request/PostTagRequest.php
@@ -25,7 +25,7 @@ class PostTagRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('tags');

--- a/src/Request/PostTagRequest.php
+++ b/src/Request/PostTagRequest.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace GrumpyDictator\FFIIIApiSupport\Request;
 
@@ -12,11 +12,10 @@ use GrumpyDictator\FFIIIApiSupport\Response\ValidationErrorResponse;
 use GuzzleHttp\Exception\GuzzleException;
 
 /**
- * Class PostTagRequest
+ * Class PostTagRequest.
  */
 class PostTagRequest extends Request
 {
-
     /**
      * PostTagRequest constructor.
      *
@@ -33,7 +32,7 @@ class PostTagRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function get(): Response
     {
@@ -41,7 +40,7 @@ class PostTagRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
@@ -49,7 +48,7 @@ class PostTagRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function post(): Response
     {

--- a/src/Request/PostTagRequest.php
+++ b/src/Request/PostTagRequest.php
@@ -22,9 +22,11 @@ class PostTagRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('tags');

--- a/src/Request/PostTransactionRequest.php
+++ b/src/Request/PostTransactionRequest.php
@@ -46,7 +46,7 @@ class PostTransactionRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('transactions');

--- a/src/Request/PostTransactionRequest.php
+++ b/src/Request/PostTransactionRequest.php
@@ -42,9 +42,11 @@ class PostTransactionRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('transactions');

--- a/src/Request/PostTransactionRequest.php
+++ b/src/Request/PostTransactionRequest.php
@@ -77,8 +77,9 @@ class PostTransactionRequest extends Request
 
         return new PostTransactionResponse($data['data']);
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {

--- a/src/Request/PutTransactionRequest.php
+++ b/src/Request/PutTransactionRequest.php
@@ -28,7 +28,7 @@ class PutTransactionRequest extends Request
      */
     public function __construct(string $url, string $token, int $groupId, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri(sprintf('transactions/%d', $groupId));

--- a/src/Request/PutTransactionRequest.php
+++ b/src/Request/PutTransactionRequest.php
@@ -1,9 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
-
 namespace GrumpyDictator\FFIIIApiSupport\Request;
-
 
 use GrumpyDictator\FFIIIApiSupport\Exceptions\ApiException;
 use GrumpyDictator\FFIIIApiSupport\Exceptions\ApiHttpException;
@@ -12,7 +11,7 @@ use GrumpyDictator\FFIIIApiSupport\Response\Response;
 use GuzzleHttp\Exception\GuzzleException;
 
 /**
- * Class PutTransactionRequest
+ * Class PutTransactionRequest.
  */
 class PutTransactionRequest extends Request
 {
@@ -37,7 +36,7 @@ class PutTransactionRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function get(): Response
     {
@@ -45,7 +44,7 @@ class PutTransactionRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function post(): Response
     {
@@ -53,7 +52,7 @@ class PutTransactionRequest extends Request
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {
@@ -64,6 +63,5 @@ class PutTransactionRequest extends Request
         }
 
         return new PostTransactionResponse($data['data']);
-
     }
 }

--- a/src/Request/PutTransactionRequest.php
+++ b/src/Request/PutTransactionRequest.php
@@ -25,9 +25,11 @@ class PutTransactionRequest extends Request
      * @param string $url
      * @param string $token
      * @param int    $groupId
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token, int $groupId)
+    public function __construct(string $url, string $token, int $groupId, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri(sprintf('transactions/%d', $groupId));

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -47,17 +47,8 @@ abstract class Request
     private $token;
     /** @var string */
     private $uri;
-    /** @var string */
-    private $trustedCertPath;
-
-    /**
-     * Request constructor.
-     * @param string $trustedCertPath path to trusted self signed certificate. Supply null to use system certificates.
-     */
-    public function __construct(string $trustedCertPath)
-    {
-        $this->trustedCertPath = $trustedCertPath;
-    }
+    /** @var string|null path to trusted self signed certificate. Supply null to use system certificates. */
+    protected $trustedCertPath = null;
 
     /**
      * @throws ApiHttpException

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -191,8 +191,8 @@ abstract class Request
         $client = $this->getClient();
         $options = [
             'headers' => [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json',
                 'Authorization' => sprintf('Bearer %s', $this->getToken()),
             ],
             'exceptions' => false,
@@ -242,8 +242,8 @@ abstract class Request
         $client = $this->getClient();
         $options = [
             'headers' => [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json',
                 'Authorization' => sprintf('Bearer %s', $this->getToken()),
             ],
             'exceptions' => false,
@@ -295,8 +295,8 @@ abstract class Request
             $res = $client->request(
                 'GET', $fullUri, [
                     'headers' => [
-                        'Accept' => 'application/json',
-                        'Content-Type' => 'application/json',
+                        'Accept'        => 'application/json',
+                        'Content-Type'  => 'application/json',
                         'Authorization' => sprintf('Bearer %s', $this->getToken()),
                     ],
                 ]

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -37,6 +37,8 @@ use GuzzleHttp\Exception\GuzzleException;
 abstract class Request
 {
     protected const VALIDATION_ERROR_MSG = 'The given data was invalid.';
+    /** @var string|null path to trusted self signed certificate. Supply null to use system certificates. */
+    protected $trustedCertPath = null;
     /** @var string */
     private $base;
     /** @var array */
@@ -47,8 +49,6 @@ abstract class Request
     private $token;
     /** @var string */
     private $uri;
-    /** @var string|null path to trusted self signed certificate. Supply null to use system certificates. */
-    protected $trustedCertPath = null;
 
     /**
      * @throws ApiHttpException

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -60,14 +60,14 @@ abstract class Request
     }
 
     /**
-     * @return Response
      * @throws ApiHttpException
+     * @return Response
      */
     abstract public function get(): Response;
 
     /**
-     * @return Response
      * @throws ApiHttpException
+     * @return Response
      */
     abstract public function put(): Response;
 
@@ -160,15 +160,15 @@ abstract class Request
     }
 
     /**
-     * @return Response
      * @throws ApiHttpException
+     * @return Response
      */
     abstract public function post(): Response;
 
     /**
-     * @return array
      * @throws GuzzleException
      * @throws ApiException
+     * @return array
      */
     protected function authenticatedGet(): array
     {
@@ -178,9 +178,9 @@ abstract class Request
     }
 
     /**
-     * @return array
      * @throws GuzzleException
      * @throws ApiException
+     * @return array
      */
     protected function authenticatedPost(): array
     {
@@ -196,7 +196,7 @@ abstract class Request
                 'Authorization' => sprintf('Bearer %s', $this->getToken()),
             ],
             'exceptions' => false,
-            'body' => (string)json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
+            'body' => (string) json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
         ];
 
         $debugOpt = $options;
@@ -205,7 +205,7 @@ abstract class Request
         $res = $client->request('POST', $fullUri, $options);
 
         if (422 === $res->getStatusCode()) {
-            $body = (string)$res->getBody();
+            $body = (string) $res->getBody();
             $json = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
             if (null === $json) {
@@ -215,10 +215,10 @@ abstract class Request
             return $json;
         }
         if (200 !== $res->getStatusCode()) {
-            throw new ApiException(sprintf('Status code is %d: %s', $res->getStatusCode(), (string)$res->getBody()));
+            throw new ApiException(sprintf('Status code is %d: %s', $res->getStatusCode(), (string) $res->getBody()));
         }
 
-        $body = (string)$res->getBody();
+        $body = (string) $res->getBody();
         $json = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
         if (null === $json) {
@@ -229,9 +229,9 @@ abstract class Request
     }
 
     /**
-     * @return array
      * @throws GuzzleException
      * @throws ApiException
+     * @return array
      */
     protected function authenticatedPut(): array
     {
@@ -247,7 +247,7 @@ abstract class Request
                 'Authorization' => sprintf('Bearer %s', $this->getToken()),
             ],
             'exceptions' => false,
-            'body' => (string)json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
+            'body' => (string) json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
         ];
 
         $debugOpt = $options;
@@ -256,7 +256,7 @@ abstract class Request
         $res = $client->request('PUT', $fullUri, $options);
 
         if (422 === $res->getStatusCode()) {
-            $body = (string)$res->getBody();
+            $body = (string) $res->getBody();
             $json = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
             if (null === $json) {
@@ -266,10 +266,10 @@ abstract class Request
             return $json;
         }
         if (200 !== $res->getStatusCode()) {
-            throw new ApiException(sprintf('Status code is %d: %s', $res->getStatusCode(), (string)$res->getBody()));
+            throw new ApiException(sprintf('Status code is %d: %s', $res->getStatusCode(), (string) $res->getBody()));
         }
 
-        $body = (string)$res->getBody();
+        $body = (string) $res->getBody();
         $json = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
         if (null === $json) {
@@ -280,8 +280,8 @@ abstract class Request
     }
 
     /**
-     * @return array
      * @throws ApiException
+     * @return array
      */
     private function freshAuthenticatedGet(): array
     {
@@ -305,10 +305,10 @@ abstract class Request
             throw new ApiException(sprintf('GuzzleException: %s', $e->getMessage()));
         }
         if (200 !== $res->getStatusCode()) {
-            throw new ApiException(sprintf('Error accessing %s. Status code is %d. Body is: %s', $fullUri, $res->getStatusCode(), (string)$res->getBody()));
+            throw new ApiException(sprintf('Error accessing %s. Status code is %d. Body is: %s', $fullUri, $res->getStatusCode(), (string) $res->getBody()));
         }
 
-        $body = (string)$res->getBody();
+        $body = (string) $res->getBody();
         $json = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
 
         if (null === $json) {
@@ -324,8 +324,8 @@ abstract class Request
     private function getClient(): Client
     {
         // config here
-        return new Client(array (
-            'verify' => ($this->trustedCertPath !== null) ? $this->trustedCertPath : true
-        ));
+        return new Client([
+            'verify' => (null !== $this->trustedCertPath) ? $this->trustedCertPath : true,
+        ]);
     }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -47,6 +47,17 @@ abstract class Request
     private $token;
     /** @var string */
     private $uri;
+    /** @var string */
+    private $trustedCertPath;
+
+    /**
+     * Request constructor.
+     * @param string $trustedCertPath path to trusted self signed certificate. Supply null to use system certificates.
+     */
+    public function __construct(string $trustedCertPath)
+    {
+        $this->trustedCertPath = $trustedCertPath;
+    }
 
     /**
      * @return Response
@@ -177,15 +188,15 @@ abstract class Request
         if (null !== $this->parameters) {
             $fullUri = sprintf('%s?%s', $fullUri, http_build_query($this->parameters));
         }
-        $client  = $this->getClient();
+        $client = $this->getClient();
         $options = [
-            'headers'    => [
-                'Accept'        => 'application/json',
-                'Content-Type'  => 'application/json',
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
                 'Authorization' => sprintf('Bearer %s', $this->getToken()),
             ],
             'exceptions' => false,
-            'body'       => (string)json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
+            'body' => (string)json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
         ];
 
         $debugOpt = $options;
@@ -228,15 +239,15 @@ abstract class Request
         if (null !== $this->parameters) {
             $fullUri = sprintf('%s?%s', $fullUri, http_build_query($this->parameters));
         }
-        $client  = $this->getClient();
+        $client = $this->getClient();
         $options = [
-            'headers'    => [
-                'Accept'        => 'application/json',
-                'Content-Type'  => 'application/json',
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
                 'Authorization' => sprintf('Bearer %s', $this->getToken()),
             ],
             'exceptions' => false,
-            'body'       => (string)json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
+            'body' => (string)json_encode($this->getBody(), JSON_THROW_ON_ERROR, 512),
         ];
 
         $debugOpt = $options;
@@ -283,12 +294,12 @@ abstract class Request
         try {
             $res = $client->request(
                 'GET', $fullUri, [
-                         'headers' => [
-                             'Accept'        => 'application/json',
-                             'Content-Type'  => 'application/json',
-                             'Authorization' => sprintf('Bearer %s', $this->getToken()),
-                         ],
-                     ]
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Content-Type' => 'application/json',
+                        'Authorization' => sprintf('Bearer %s', $this->getToken()),
+                    ],
+                ]
             );
         } catch (Exception $e) {
             throw new ApiException(sprintf('GuzzleException: %s', $e->getMessage()));
@@ -313,7 +324,8 @@ abstract class Request
     private function getClient(): Client
     {
         // config here
-
-        return new Client;
+        return new Client(array (
+            'verify' => ($this->trustedCertPath !== null) ? $this->trustedCertPath : true
+        ));
     }
 }

--- a/src/Request/SystemInformationRequest.php
+++ b/src/Request/SystemInformationRequest.php
@@ -41,9 +41,11 @@ class SystemInformationRequest extends Request
      *
      * @param string $url
      * @param string $token
+     * @param string|null $trustedCertPath (optional) path to trusted (self-signed) certificate
      */
-    public function __construct(string $url, string $token)
+    public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
+        parent::__construct($trustedCertPath);
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('about');

--- a/src/Request/SystemInformationRequest.php
+++ b/src/Request/SystemInformationRequest.php
@@ -45,7 +45,7 @@ class SystemInformationRequest extends Request
      */
     public function __construct(string $url, string $token, string $trustedCertPath = null)
     {
-        parent::__construct($trustedCertPath);
+        $this->trustedCertPath = $trustedCertPath;
         $this->setBase($url);
         $this->setToken($token);
         $this->setUri('about');

--- a/src/Request/SystemInformationRequest.php
+++ b/src/Request/SystemInformationRequest.php
@@ -73,8 +73,9 @@ class SystemInformationRequest extends Request
     {
         // TODO: Implement post() method.
     }
+
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function put(): Response
     {


### PR DESCRIPTION
This PR is related to firefly-iii/spectre-importer#2 and adds a `$trustedCertificate` parameter to the `Request` classes. 
The default value of the parameter is `null` which will result in `Guzzle.Client.validate == true` and the use of the operating system truststore according to the [docs](http://docs.guzzlephp.org/en/stable/request-options.html#verify).

This change should add no errors in "third party" code. ~~unless a class in it overrides `Request`. In that case it can be fixed by calling `parent::__construct(null);` if no self-signed certificates will be used.~~
